### PR TITLE
Add Midje support to a Leiningen project

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -35,3 +35,19 @@ generator:
     - "project_name": "rug-function-http"
     - "package_name": "com.atomist.rug.functions"
 
+---
+kind: "operation"
+client: "atomist"
+editor:
+  name: "atomist-rugs.lein-editors.AddMidje"
+  group: "atomist-rugs"
+  artifact: "lein-editors"
+  version: "1.3.1"
+  origin:
+    repo: "https://github.com/atomist-rugs/lein-editors.git"
+    branch: "d8b2ee4916e3c740e01d2865cfd3f48f3009d436"
+    sha: "d8b2ee4*"
+  parameters:
+    - "midje_version": "1.8.3"
+    - "midje_plugin_version": "3.1.3"
+

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,5 @@
 (defproject com.atomist.rug.functions/rug-function-http "0.0.1-SNAPSHOT"
   :description "HTTP Rug Function"
-  :dependencies [[org.clojure/clojure "1.8.0"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :profiles {:dev {:dependencies [[midje "1.8.3"]]
+                   :plugins [[lein-midje "3.1.3"]]}})


### PR DESCRIPTION
Created by Atomist Editor `atomist-rugs.lein-editors.AddMidje`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "atomist-rugs.lein-editors.AddMidje"
  group: "atomist-rugs"
  artifact: "lein-editors"
  version: "1.3.1"
  origin:
    repo: "https://github.com/atomist-rugs/lein-editors.git"
    branch: "d8b2ee4916e3c740e01d2865cfd3f48f3009d436"
    sha: "d8b2ee4*"
  parameters:
    - "midje_version": "1.8.3"
    - "midje_plugin_version": "3.1.3"

```