### PR TITLE
Make whitelist URLs safer

### DIFF
--- a/src/com/atomist/rug/functions/rug_function_http/whitelist.clj
+++ b/src/com/atomist/rug/functions/rug_function_http/whitelist.clj
@@ -18,8 +18,8 @@
    :travis-org       {:patterns #{"^https://api\\.travis-ci\\.org/.*$"}}
    :xkcd             {:patterns #{"^http://xkcd\\.com/.*$"}}
    :npm              {:patterns #{"^https://registry\\.npmjs\\.org/.*$"}}
-   :jfrog            {:patterns #{"^https://.+?\\.jfrog\\.io/.*$"}}
-   :aws              {:patterns #{"^https://.+?\\.amazonaws\\.com/.*$"}}
+   :jfrog            {:patterns #{"^https://[^/]+?\\.jfrog\\.io/.*$"}}
+   :aws              {:patterns #{"^https://[^/]+?\\.amazonaws\\.com/.*$"}}
    :slack            {:patterns #{"^https://slack\\.com/api/.*$"}}
    :atomist-webhooks {:patterns #{"^https://webhook\\.atomist\\.com/.*$"}}})
 


### PR DESCRIPTION
Do not allow forward slash in wildcard matches in hostname.