### PR TITLE
Whitelist the TLD for Pivotal Web Services

### DIFF
--- a/src/com/atomist/rug/functions/rug_function_http/whitelist.clj
+++ b/src/com/atomist/rug/functions/rug_function_http/whitelist.clj
@@ -20,6 +20,7 @@
    :npm              {:patterns #{"^https://registry\\.npmjs\\.org/.*$"}}
    :jfrog            {:patterns #{"^https://[^/]+?\\.jfrog\\.io/.*$"}}
    :aws              {:patterns #{"^https://[^/]+?\\.amazonaws\\.com/.*$"}}
+   :pivotalws        {:patterns #{"^http://api\\.run\\.pivotal\\.io/.*$"}}
    :slack            {:patterns #{"^https://slack\\.com/api/.*$"}}
    :atomist-webhooks {:patterns #{"^https://webhook\\.atomist\\.com/.*$"}}})
 


### PR DESCRIPTION
This will let me make API calls against Cloud Foundry in the Cloud